### PR TITLE
fix: 서버 데이터 수정에 의해 불러오는 방식 변경

### DIFF
--- a/src/components/pages/itemDetail/ItemDetail.jsx
+++ b/src/components/pages/itemDetail/ItemDetail.jsx
@@ -27,31 +27,19 @@ const ItemDetail = () => {
 
   const itemList = useSelector((state) => state.dataList.itemList);
   console.log(itemList);
-  // const jsonString = itemList.content;
 
-  // try {
-  //   const jsonArray = JSON.parse(jsonString);
-  //   console.log(jsonArray); // JavaScript 배열로 변환된 값 출력
-  // } catch (error) {
-  //   console.error("유효하지 않은 JSON 배열 형식입니다.");
-  // }
-  const urlRegex = /https?:\/\/[^"]+/g;
-  const contentImageUrlArr = itemList?.content?.match(urlRegex);
-  const coverImageUrlArr = itemList?.coverImage?.match(urlRegex);
+  const jsonCoverImage = itemList?.coverImage;
+  const jsonContent = itemList?.content;
 
-  const coverImageUrl =
-    itemList && itemList.coverImage ? coverImageUrlArr[0] : "";
-
-  const contentImageUrlArrExceptLast = contentImageUrlArr?.slice(
-    0,
-    coverImageUrlArr.length - 1
-  );
+  const coverImageUrlArr = JSON.parse(jsonCoverImage ?? "[]");
+  const contentImageUrlArr = JSON.parse(jsonContent ?? "[]");
+  console.log(coverImageUrlArr, contentImageUrlArr);
 
   return (
     <StContainer>
       <StItemDetailTop>
         <div>
-          <img src={coverImageUrl} />
+          <img src={coverImageUrlArr[0]} />
         </div>
         {itemList ? (
           <div>
@@ -94,8 +82,8 @@ const ItemDetail = () => {
         )}
       </StItemDetailTop>
       <span>
-        {contentImageUrlArrExceptLast &&
-          contentImageUrlArrExceptLast.map((img) => <img src={img} />)}
+        {contentImageUrlArr &&
+          contentImageUrlArr.map((img) => <img src={img} />)}
       </span>
     </StContainer>
   );


### PR DESCRIPTION
✔️ 서버 데이터 수정에 의해 url 불러오는 방식 변경

- 기존 url 방식: json형식 변환 불가능한 string값
(서버에서 데이터 뒷부분이 잘려 배열이 닫히지 않음, 마지막 값은 중간에서 잘려 유효하지 않음)
-> 프론트에서 정규표현식으로 필터링

-  수정된 url 방식: 서버 데이터 json 변환가능한  string값
- -> 프론트에서 정규표현식 과정을 생략하고 json 형식으로 변환